### PR TITLE
Fixes to run on 1.9

### DIFF
--- a/lib/logstash-cli/cli.rb
+++ b/lib/logstash-cli/cli.rb
@@ -4,7 +4,11 @@ require 'rack'
 require 'amqp'
 require 'tire'
 require 'time'
-require 'fastercsv'
+if RUBY_VERSION > '1.9'
+  require 'csv'
+else
+  require 'fastercsv'
+end
 require 'logstash-cli/command'
 
 module LogstashCli

--- a/lib/logstash-cli/command.rb
+++ b/lib/logstash-cli/command.rb
@@ -1,7 +1,9 @@
 require 'logstash-cli/command/grep'
 require 'logstash-cli/command/tail'
 
-module LogstashCli::Command
-  include Grep
-  include Tail
+module LogstashCli
+  module Command
+    include Grep
+    include Tail
+  end
 end


### PR DESCRIPTION
- FasterCSV cannot be used on 1.9
- You assume LogstashCli has been declared already as a module, which doesn't seem to happen in 1.9 (for some reason I didn't bother to find out why)
