### PR TITLE
remove bundler/setup from cli.rb

### DIFF
--- a/lib/logstash-cli/cli.rb
+++ b/lib/logstash-cli/cli.rb
@@ -1,5 +1,4 @@
 require 'rubygems'
-require 'bundler/setup'
 require 'rack'
 require 'amqp'
 require 'tire'


### PR DESCRIPTION
Hey Patrick,

I've got another fix for you. If you run logstash-cli anywhere that has a Gemfile, requires break if they don't exist in that gemfile, e.g. for a rails app that doesn't have `amqp` in the Gemfile.

The solution here is to remove the 'bundler/setup' require which then relies on rubygems to do the resolution, which is the ideal for gem-based installations. This shouldn't break 'bundle exec logstash-cli' for development, but please let me know if it does and I will send you more patches.

If you find this patch satisfactory, and don't mind cutting another release, I would really appreciate it.
