### PR TITLE
In the count command, ensure when printing results that the term goes first

### DIFF
--- a/lib/logstash-cli/command/count.rb
+++ b/lib/logstash-cli/command/count.rb
@@ -65,7 +65,8 @@ module Count
         puts _format(header, options)
 
         results['terms'].each do |terms|
-          puts _format(terms.values, options)
+          result = [ terms['term'], terms['count'] ]
+          puts _format(result, options)
 
           unless fields.empty? and metafields.empty?
             term = terms['term']

--- a/lib/logstash-cli/command/tail.rb
+++ b/lib/logstash-cli/command/tail.rb
@@ -36,7 +36,7 @@ module Tail
 
         channel = AMQP::Channel.new(connection, :auto_recovery => true)
 
-        channel.queue("", :auto_delete => auto_delete, :peristent => persistent , :durable => durable)   do |queue, declare_ok|
+        channel.queue("", :auto_delete => auto_delete, :persistent => persistent , :durable => durable)   do |queue, declare_ok|
           queue.bind(exchange_name, :routing_key => routing_key)
           queue.subscribe do |payload|
             parsed_message = JSON.parse(payload)


### PR DESCRIPTION
Also made a typo fix during AMQP queue creation.
