### PR TITLE
Add 1.8.7 Compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem "logstash-cli", :path => "."
 
 group :test do
   gem "rake"
+  gem "rspec"
 end
 
 gemspec

--- a/lib/logstash-cli/command/grep.rb
+++ b/lib/logstash-cli/command/grep.rb
@@ -12,7 +12,8 @@ module Grep
 
   # Very naive time range description parsing.
   def self.parse_time_range(desc)
-    /(?<value>\d+)\s*(?<units>\w*)/ =~ desc
+    /(\d+)\s*(\w*)/ =~ desc
+    value, units = $1, $2
     value = value.to_i
     start = case units.to_s.downcase
             when 'm', 'min', 'mins', 'minute', 'minutes'

--- a/lib/logstash-cli/command/grep.rb
+++ b/lib/logstash-cli/command/grep.rb
@@ -41,12 +41,14 @@ module Grep
     fields = options[:fields].split(',')
 
     begin
-      if options[:last].nil?
-        from_time = Time.parse(options[:from])
-        to_time = Time.parse(options[:to])
-      else
-        from_time, to_time = Grep.parse_time_range(options[:last])
-      end
+      from_time, to_time = if options[:from] && options[:to]
+                             [ Time.parse(options[:from]),
+                               Time.parse(options[:to]) ]
+                           elsif options[:from] && ! options[:to]
+                             [Time.parse(options[:from]), Time.now]
+                           elsif options[:last]
+                             Grep.parse_time_range(options[:last])
+                           end
     rescue ArgumentError
       $stderr.puts "Something went wrong while parsing the date range."
       exit -1

--- a/spec/logstash-cli/command/grep_spec.rb
+++ b/spec/logstash-cli/command/grep_spec.rb
@@ -1,5 +1,5 @@
-require_relative '../../spec_helper.rb'
-require_relative '../../../lib/logstash-cli/command/grep.rb'
+require 'spec_helper'
+require 'logstash-cli/command/grep'
 
 describe Grep do
   it "determines index range needed for a given date range" do

--- a/spec/logstash-cli/command/grep_spec.rb
+++ b/spec/logstash-cli/command/grep_spec.rb
@@ -3,51 +3,53 @@ require 'logstash-cli/command/grep'
 
 describe Grep do
   it "determines index range needed for a given date range" do
-    Grep.indexes_from_interval(DateTime.now, DateTime.now).should == [DateTime.now.to_date.to_s.gsub('-', '.')]
+    from = 1358832972
+    to = 1359005772
+    Grep.indexes_from_interval(Time.at(from), Time.at(to)).should == ["2013.01.21", "2013.01.22", "2013.01.23"]
   end
 
   it "calculates time range required to search last X minutes" do
     # The to_i removes fractions seconds.  Unsure on the best way to test this.
-    diff = 10*(1/60.0*24.0)
-    Grep.parse_time_range("10m").map{|t| t.to_time.to_i}.should == [DateTime.now - diff, DateTime.now].map{|t| t.to_time.to_i}
-    Grep.parse_time_range("10mins").map{|t| t.to_time.to_i}.should == [DateTime.now - diff, DateTime.now].map{|t| t.to_time.to_i}
-    Grep.parse_time_range("10 min").map{|t| t.to_time.to_i}.should == [DateTime.now - diff, DateTime.now].map{|t| t.to_time.to_i}
-    Grep.parse_time_range("10 minute").map{|t| t.to_time.to_i}.should == [DateTime.now - diff, DateTime.now].map{|t| t.to_time.to_i}
-    Grep.parse_time_range("10 minutes").map{|t| t.to_time.to_i}.should == [DateTime.now - diff, DateTime.now].map{|t| t.to_time.to_i}
+    diff = 10*60
+    Grep.parse_time_range("10m").map{|t| t.to_i}.should == [Time.now - diff, Time.now].map{|t| t.to_i}
+    Grep.parse_time_range("10mins").map{|t| t.to_i}.should == [Time.now - diff, Time.now].map{|t| t.to_i}
+    Grep.parse_time_range("10 min").map{|t| t.to_i}.should == [Time.now - diff, Time.now].map{|t| t.to_i}
+    Grep.parse_time_range("10 minute").map{|t| t.to_i}.should == [Time.now - diff, Time.now].map{|t| t.to_i}
+    Grep.parse_time_range("10 minutes").map{|t| t.to_i}.should == [Time.now - diff, Time.now].map{|t| t.to_i}
   end
 
   it "calculates time range required to search last X hours" do
-    diff = 10*(1/24.0)
-    Grep.parse_time_range("10h").map{|t| t.to_time.to_i}.should == [DateTime.now - diff, DateTime.now].map{|t| t.to_time.to_i}
-    Grep.parse_time_range("10hr").map{|t| t.to_time.to_i}.should == [DateTime.now - diff, DateTime.now].map{|t| t.to_time.to_i}
-    Grep.parse_time_range("10hrs").map{|t| t.to_time.to_i}.should == [DateTime.now - diff, DateTime.now].map{|t| t.to_time.to_i}
-    Grep.parse_time_range("10 hour").map{|t| t.to_time.to_i}.should == [DateTime.now - diff, DateTime.now].map{|t| t.to_time.to_i}
-    Grep.parse_time_range("10 hours").map{|t| t.to_time.to_i}.should == [DateTime.now - diff, DateTime.now].map{|t| t.to_time.to_i}
+    diff = 10*60*60
+    Grep.parse_time_range("10h").map{|t| t.to_i}.should == [Time.now - diff, Time.now].map{|t| t.to_i}
+    Grep.parse_time_range("10hr").map{|t| t.to_i}.should == [Time.now - diff, Time.now].map{|t| t.to_i}
+    Grep.parse_time_range("10hrs").map{|t| t.to_i}.should == [Time.now - diff, Time.now].map{|t| t.to_i}
+    Grep.parse_time_range("10 hour").map{|t| t.to_i}.should == [Time.now - diff, Time.now].map{|t| t.to_i}
+    Grep.parse_time_range("10 hours").map{|t| t.to_i}.should == [Time.now - diff, Time.now].map{|t| t.to_i}
   end
 
   it "calculates time range required to search last X days" do
-    diff = 10
-    Grep.parse_time_range("10d").map{|t| t.to_time.to_i}.should == [DateTime.now - diff, DateTime.now].map{|t| t.to_time.to_i}
-    Grep.parse_time_range("10days").map{|t| t.to_time.to_i}.should == [DateTime.now - diff, DateTime.now].map{|t| t.to_time.to_i}
-    Grep.parse_time_range("10 day").map{|t| t.to_time.to_i}.should == [DateTime.now - diff, DateTime.now].map{|t| t.to_time.to_i}
+    diff = 10*86400
+    Grep.parse_time_range("10d").map{|t| t.to_i}.should == [Time.now - diff, Time.now].map{|t| t.to_i}
+    Grep.parse_time_range("10days").map{|t| t.to_i}.should == [Time.now - diff, Time.now].map{|t| t.to_i}
+    Grep.parse_time_range("10 day").map{|t| t.to_i}.should == [Time.now - diff, Time.now].map{|t| t.to_i}
   end
 
   it "calculates time range required to search last X weeks" do
-    diff = 10*7
-    Grep.parse_time_range("10w").map{|t| t.to_time.to_i}.should == [DateTime.now - diff, DateTime.now].map{|t| t.to_time.to_i}
-    Grep.parse_time_range("10wk").map{|t| t.to_time.to_i}.should == [DateTime.now - diff, DateTime.now].map{|t| t.to_time.to_i}
-    Grep.parse_time_range("10 wks").map{|t| t.to_time.to_i}.should == [DateTime.now - diff, DateTime.now].map{|t| t.to_time.to_i}
-    Grep.parse_time_range("10 week").map{|t| t.to_time.to_i}.should == [DateTime.now - diff, DateTime.now].map{|t| t.to_time.to_i}
-    Grep.parse_time_range("10 weeks").map{|t| t.to_time.to_i}.should == [DateTime.now - diff, DateTime.now].map{|t| t.to_time.to_i}
+    diff = 10*7*86400
+    Grep.parse_time_range("10w").map{|t| t.to_i}.should == [Time.now - diff, Time.now].map{|t| t.to_i}
+    Grep.parse_time_range("10wk").map{|t| t.to_i}.should == [Time.now - diff, Time.now].map{|t| t.to_i}
+    Grep.parse_time_range("10 wks").map{|t| t.to_i}.should == [Time.now - diff, Time.now].map{|t| t.to_i}
+    Grep.parse_time_range("10 week").map{|t| t.to_i}.should == [Time.now - diff, Time.now].map{|t| t.to_i}
+    Grep.parse_time_range("10 weeks").map{|t| t.to_i}.should == [Time.now - diff, Time.now].map{|t| t.to_i}
   end
 
   it "calculates time range required to search last X years" do
-    diff = 10*365
-    Grep.parse_time_range("10y").map{|t| t.to_time.to_i}.should == [DateTime.now - diff, DateTime.now].map{|t| t.to_time.to_i}
-    Grep.parse_time_range("10 yr").map{|t| t.to_time.to_i}.should == [DateTime.now - diff, DateTime.now].map{|t| t.to_time.to_i}
-    Grep.parse_time_range("10 yrs").map{|t| t.to_time.to_i}.should == [DateTime.now - diff, DateTime.now].map{|t| t.to_time.to_i}
-    Grep.parse_time_range("10 year").map{|t| t.to_time.to_i}.should == [DateTime.now - diff, DateTime.now].map{|t| t.to_time.to_i}
-    Grep.parse_time_range("10 years").map{|t| t.to_time.to_i}.should == [DateTime.now - diff, DateTime.now].map{|t| t.to_time.to_i}
+    diff = 10*365*86400
+    Grep.parse_time_range("10y").map{|t| t.to_i}.should == [Time.now - diff, Time.now].map{|t| t.to_i}
+    Grep.parse_time_range("10 yr").map{|t| t.to_i}.should == [Time.now - diff, Time.now].map{|t| t.to_i}
+    Grep.parse_time_range("10 yrs").map{|t| t.to_i}.should == [Time.now - diff, Time.now].map{|t| t.to_i}
+    Grep.parse_time_range("10 year").map{|t| t.to_i}.should == [Time.now - diff, Time.now].map{|t| t.to_i}
+    Grep.parse_time_range("10 years").map{|t| t.to_i}.should == [Time.now - diff, Time.now].map{|t| t.to_i}
   end
 
   it "raises an ArgumentError if it can't cacluate the time range" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+$:.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+$:.unshift(File.expand_path("../lib", __FILE__))
+$:.unshift(File.dirname(__FILE__))


### PR DESCRIPTION
Logstash 0.7 broke compatibility with Ruby 1.8.7 because of its use of
1.9-only regular expression syntax and methods in the DateTime class.
This commit improves 1.8.7 compatibility by
- Removing the named capture syntax
- Move from the DateTime to the Time class

Resolves issue #10.
